### PR TITLE
Use schema relative urls for resources

### DIFF
--- a/403-error.html
+++ b/403-error.html
@@ -9,8 +9,8 @@
     <title>403 Error</title>
 
     <!-- Bootstrap core CSS -->
-    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.0-wip/css/bootstrap.min.css">
-    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css">
+    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.0-wip/css/bootstrap.min.css">
+    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css">
 
     <!-- Custom styles for this template -->
 
@@ -148,7 +148,7 @@
                         <script type="text/javascript">
                             function checkSite(){
                               var currentSite = window.location.hostname;
-                                window.location = "http://" + currentSite;
+                                window.location = "//" + currentSite;
                             }
                         </script></p>
     </div>

--- a/404-error.html
+++ b/404-error.html
@@ -9,8 +9,8 @@
     <title>404 Error</title>
 
     <!-- Bootstrap core CSS -->
-    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.0-wip/css/bootstrap.min.css">
-    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css">
+    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.0-wip/css/bootstrap.min.css">
+    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css">
 
     <!-- Custom styles for this template -->
 
@@ -148,7 +148,7 @@
                         <script type="text/javascript">
                             function checkSite(){
                               var currentSite = window.location.hostname;
-                                window.location = "http://" + currentSite;
+                                window.location = "//" + currentSite;
                             }
                         </script></p>
     </div>

--- a/500-error.html
+++ b/500-error.html
@@ -9,11 +9,11 @@
     <title>500 Error</title>
 
     <!-- Bootstrap core CSS -->
-    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.0-wip/css/bootstrap.min.css">
-    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css">
+    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.0-wip/css/bootstrap.min.css">
+    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css">
 
     <!-- Latest Glyphicons minified CSS -->
-    <link href="http://netdna.bootstrapcdn.com/bootstrap/3.0.0-rc2/css/bootstrap-glyphicons.css" rel="stylesheet">
+    <link href="//netdna.bootstrapcdn.com/bootstrap/3.0.0-rc2/css/bootstrap-glyphicons.css" rel="stylesheet">
 
     <style>
     /* Page Layout CSS */

--- a/502-error.html
+++ b/502-error.html
@@ -9,8 +9,8 @@
     <title>502 Bad Gateway Error</title>
 
     <!-- Bootstrap core CSS -->
-    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.0-wip/css/bootstrap.min.css">
-    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css">
+    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.0-wip/css/bootstrap.min.css">
+    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css">
 
     <!-- Custom styles for this template -->
 

--- a/503-error.html
+++ b/503-error.html
@@ -9,8 +9,8 @@
     <title>503 Error</title>
 
     <!-- Bootstrap core CSS -->
-    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.0-wip/css/bootstrap.min.css">
-    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css">
+    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.0-wip/css/bootstrap.min.css">
+    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css">
 
     <!-- Custom styles for this template -->
 

--- a/504-error.html
+++ b/504-error.html
@@ -9,8 +9,8 @@
     <title>504 Error</title>
 
     <!-- Bootstrap core CSS -->
-    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.0-wip/css/bootstrap.min.css">
-    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css">
+    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.0-wip/css/bootstrap.min.css">
+    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css">
 
 
 

--- a/Maintenance-Page.html
+++ b/Maintenance-Page.html
@@ -9,8 +9,8 @@
     <title>Temporary Maintenance</title>
 
     <!-- Bootstrap core CSS -->
-    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.0-wip/css/bootstrap.min.css">
-    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css">
+    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.0-wip/css/bootstrap.min.css">
+    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css">
 
     <!-- Custom styles for this template -->
 


### PR DESCRIPTION
When the production site is secure (https) then, when showing the Maintenance page, CSS are blocked by browser because they were referenced with http://

I removed http:// and left // to let the browser use the current page protocol.
